### PR TITLE
Push tag versions to quay

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,6 +29,7 @@ pipeline:
       branch: master
       event:
         - push
+        - tag
         - pull_request
 
   image_to_quay:
@@ -44,3 +45,16 @@ pipeline:
     when:
       branch: master
       event: push
+
+  image_to_quay:
+    image: docker:17.09.1
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-stub quay.io/ukhomeofficedigital/asl-stub:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/asl-stub:$${DRONE_TAG}
+    when:
+      event: tag


### PR DESCRIPTION
This allows for explicitly versioned images to be pushed as well as just latest, so we can have fine-grained control over which versions are deployed.