### PR TITLE
Fix tag build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ pipeline:
     when:
       event:
         - push
+        - tag
         - pull_request
 
   audit:
@@ -17,6 +18,7 @@ pipeline:
     when:
       event:
         - push
+        - tag
         - pull_request
 
   build:
@@ -29,7 +31,6 @@ pipeline:
       branch: master
       event:
         - push
-        - tag
         - pull_request
 
   image_to_quay:
@@ -45,6 +46,15 @@ pipeline:
     when:
       branch: master
       event: push
+
+  build:
+    image: docker:17.09.1
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build -t asl-stub .
+    when:
+      event: tag
 
   image_to_quay:
     image: docker:17.09.1


### PR DESCRIPTION
You can't specify a branch name and an `event: tag` on the same build step becuase tags are detached from branches. Add a separate step for the tag docker build so it executes without a branch filter.